### PR TITLE
Changed the wrong method name to grunt.fail.warn

### DIFF
--- a/tasks/patch.js
+++ b/tasks/patch.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
       });
       
       if (!src || !src[0]) {
-        grunt.fail.warning('Patch failed. Please check your patch and its corresponding version.');
+        grunt.fail.warn('Patch failed. Please check your patch and its corresponding version.');
         return false;
       }
       // Write the destination file.


### PR DESCRIPTION
The method grunt.fail.warning does not exist.
I renamed it to grunt.fail.warn